### PR TITLE
Android security 11.0.0 release 70

### DIFF
--- a/libSBRdec/src/lpp_tran.h
+++ b/libSBRdec/src/lpp_tran.h
@@ -1,7 +1,7 @@
 /* -----------------------------------------------------------------------------
 Software License for The Fraunhofer FDK AAC Codec Library for Android
 
-© Copyright  1995 - 2018 Fraunhofer-Gesellschaft zur Förderung der angewandten
+© Copyright  1995 - 2023 Fraunhofer-Gesellschaft zur Förderung der angewandten
 Forschung e.V. All rights reserved.
 
  1.    INTRODUCTION
@@ -207,7 +207,7 @@ typedef struct {
                                             inverse filtering levels */
 
   PATCH_PARAM
-  patchParam[MAX_NUM_PATCHES]; /*!< new parameter set for patching */
+  patchParam[MAX_NUM_PATCHES + 1]; /*!< new parameter set for patching */
   WHITENING_FACTORS
   whFactors;     /*!< the pole moving factors for certain
                     whitening levels as indicated     in the bitstream


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r70' of https://android.googlesource.com/platform/external/aac into arrow-11.0

Android security 11.0.0 release 70
Tag: https://android.googlesource.com/platform/external/aac/+/refs/tags/android-security-11.0.0_r70

Merge cherrypicks of ['googleplex-android-review.googlesource.com/23497456'] into security-aosp-rvc-release.

Change-Id: [Iceece9a53bf6e37ae0302fd4419ef2abf882f470](https://android-review.googlesource.com/#/q/Iceece9a53bf6e37ae0302fd4419ef2abf882f470)